### PR TITLE
crunchydata pgo db v0.2.4

### DIFF
--- a/charts/crunchydata-pgo-db/Chart.yaml
+++ b/charts/crunchydata-pgo-db/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: crunchydata-pgo-db
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.1
-appVersion: 5.0.4
+version: 0.2.4
+appVersion: 5.1.1

--- a/charts/crunchydata-pgo-db/templates/postgres.yaml
+++ b/charts/crunchydata-pgo-db/templates/postgres.yaml
@@ -3,7 +3,7 @@ kind: PostgresCluster
 metadata:
   name: {{ default .Release.Name .Values.name }}
 spec:
-  postgresVersion: {{ default 13 .Values.postgresVersion }}
+  postgresVersion: {{ required "You must set the version of Postgres to deploy." .Values.postgresVersion }}
   {{- if .Values.postGISVersion }}
   postGISVersion: {{ quote .Values.postGISVersion }}
   {{- end }}
@@ -35,17 +35,6 @@ spec:
         limits:
           cpu: {{ default "" .Values.instanceResources.limits.cpu | quote }}
           memory: {{ default "" .Values.instanceResources.limits.memory | quote }}
-      {{- end }}
-      {{- if .Values.replicaCertCopyResources }}
-      sidecars:
-        replicaCertCopy:
-          resources:
-            requests:
-              cpu: {{ default "" .Values.replicaCertCopyResources.requests.cpu | quote }}
-              memory: {{ default "" .Values.replicaCertCopyResources.requests.memory | quote }}
-            limits:
-              cpu: {{ default "" .Values.replicaCertCopyResources.limits.cpu | quote }}
-              memory: {{ default "" .Values.replicaCertCopyResources.limits.memory | quote }}
       {{- end }}
   {{- end }}
   backups:

--- a/charts/crunchydata-pgo-db/values.yaml
+++ b/charts/crunchydata-pgo-db/values.yaml
@@ -14,8 +14,8 @@
 # postgresVersion sets the version to deploy. This version number needs to be
 # available as one of the "RELATED_IMAGE_POSTGRES_..." images as part of the PGO
 # installation if you want to deploy the image without setting the "postgres"
-# image variable. This defaults to the below value.
-# postgresVersion: 13
+# image variable. This value is required.
+postgresVersion: 14
 
 # postGISVersion if sets and coupled with a PostGIS enabled container, enables
 # PostGIS. This version number needs to be available as one of the
@@ -47,19 +47,19 @@
 # below value. "postgresVersion" needs to match the version of Postgres that is
 # used here. If using the GIS-enabled Postgres image, you need to ensure
 # "postGISVersion" matches the version of PostGIS used.
-# imagePostgres: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-0
+# imagePostgres: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-13.7-0
 
 # imagePgBackRest is the pgBackRest backup utility image. This defaults to the
 # below value.
-# imagePgBackRest: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-0
+# imagePgBackRest: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.38-1
 
 # imagePgBouncer is the image for the PgBouncer connection pooler. This defaults
 # to the below value.
-# imagePgBouncer: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.16-0
+# imagePgBouncer: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.16-3
 
 # imageExporter is the image name for the exporter used as a part of monitoring.
 # This defaults to the value below.
-# imageExporter: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.0.4-0
+# imageExporter: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.1.1-0
 
 ###########################
 # Basic Postgres Settings #
@@ -69,25 +69,27 @@
 # the value below. Setting "instances" overrides this value.
 # instanceName: instance1
 
-# instanceResources defines the resources requests and limits for the container
-# instanceResources: {}
-
 # instanceSize sets the size of the volume that contains the data. This defaults
 # to the value below. Settings "instances" overrides this value.
 # instanceSize: 1Gi
+
+# instanceResources defines the resources requests and limits for the container
+# instanceResources: {}
+
+# instanceMemory sets the memory limit for the Postgres instances. This defaults
+# to no limit being set, but an example value is set below. Settings "instances"
+# overrides this value.
+# instanceMemory: 2Gi
+
+# instanceCPU sets the CPU limit for the Postgres instances. This defaults to
+# no limit being set, but an example value is set below. Setting "instances"
+# overrides this value.
+# instanceCPU: 1000m
 
 # instanceReplicas lets you set the total number of Postgres replicas. This
 # defaults to the value below. More than on replica enables high availability
 # (HA). Settings "instances" overrides this value.
 # instanceReplicas: 1
-
-####################
-# Sidecar Settings #
-####################
-
-# replicaCertCopyResources defines the resource requests and limits for
-# for the replica cert copy sidecar container
-# replicaCertCopyResources: {}
 
 ##############################
 # Advanced Postgres Settings #


### PR DESCRIPTION
This upgrades the `crunchydata-pgo-db` chart to the upstream version of `0.2.4`.