### PR TITLE
Add a PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,14 @@ Please replace this with a high level description of what this PR is supposed to
 ### Checklist
 
  - [ ] Have you reviewed and updated the chart default values if necessary?
+ - [ ] Have you reviewed and updated the chart documentation if necessary?
  - [ ] Does your branch follow the naming convention of `{chartNameWithDashes}-v{versionString}-{optionalPatchVersion}`?
  - [ ] Have you bumped the version in the chart's `Chart.yaml`?
 
 ### Tagged Releases
-Please remember to make a tagged release and description that matches your branch name after merging this PR.
+Please remember to make a tagged release after merging your PR that:
+
+ - Has a tag name that matches your PR branch name (see above)
+ - Has a description that summarizes the changes made
+
+This makes its possible to use previous versions of the charts maintained here as new releases are published. Please see the release history of this repository for examples.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,4 +14,4 @@ Please remember to make a tagged release after merging your PR that:
  - Has a tag name that matches your PR branch name (see above)
  - Has a description that summarizes the changes made
 
-This makes its possible to use previous versions of the charts maintained here as new releases are published. Please see the release history of this repository for examples.
+This makes it possible to use previous versions of the charts maintained here as new releases are published. Please see the release history of this repository for examples.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### PR Description
+Please replace this with a high level description of what this PR is supposed to accomplish.
+
+### Checklist
+
+ - [ ] Have you reviewed and updated the chart default values if necessary?
+ - [ ] Does your branch follow the naming convention of `{chartNameWithDashes}-v{versionString}-{optionalPatchVersion}`?
+ - [ ] Have you bumped the version in the chart's `Chart.yaml`?
+
+### Tagged Releases
+Please remember to make a tagged release and description that matches your branch name after merging this PR.


### PR DESCRIPTION
This adds a PR template to try and remind contributors of things that need to be considered when publishing a new version of a chart.