### PR TITLE
Release new operator chart for postgres 13.8

### DIFF
--- a/charts/crunchydata-pgo/Chart.yaml
+++ b/charts/crunchydata-pgo/Chart.yaml
@@ -3,5 +3,5 @@ name: crunchydata-pgo
 description: Installer for PGO, the open source Postgres Operator from Crunchy Data
 
 type: application
-version: 0.3.1-3
+version: 0.3.1-4
 appVersion: 5.1.1

--- a/charts/crunchydata-pgo/values.yaml
+++ b/charts/crunchydata-pgo/values.yaml
@@ -13,11 +13,11 @@ relatedImages:
   postgres_14_gis_3.2:
     image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.3-3.2-0
   postgres_13:
-    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-13.7-0
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-13.8-0
   postgres_13_gis_3.0:
-    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.7-3.0-0
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.8-3.0-0
   postgres_13_gis_3.1:
-    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.7-3.1-0
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.8-3.1-0
   pgadmin:
     image: registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi8-4.30-1
   pgbackrest:


### PR DESCRIPTION
### PR Description
This creates a new release of the `crunchydata-pgo` chart to use postgres 13.8 (upgrade from 13.7).

### Checklist

 - [x] Have you reviewed and updated the chart default values if necessary?
 - [x] Have you reviewed and updated the chart documentation if necessary?
 - [x] Does your branch follow the naming convention of `{chartNameWithDashes}-v{versionString}-{optionalPatchVersion}`?
 - [x] Have you bumped the version in the chart's `Chart.yaml`?

### Tagged Releases
Please remember to make a tagged release after merging your PR that:

 - Has a tag name that matches your PR branch name (see above)
 - Has a description that summarizes the changes made

This makes it possible to use previous versions of the charts maintained here as new releases are published. Please see the release history of this repository for examples.
