### PR TITLE
Add nginx-ldapauth-proxy allowing to set authorization header

### DIFF
--- a/charts/nginx-ldapauth-proxy/.helmignore
+++ b/charts/nginx-ldapauth-proxy/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/nginx-ldapauth-proxy/Chart.yaml
+++ b/charts/nginx-ldapauth-proxy/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+description: nginx proxy with ldapauth
+name: nginx-ldapauth-proxy
+icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
+version: 0.1.4
+appVersion: 1.13.5
+sources:
+- https://github.com/dweomer/dockerfiles-nginx-auth-ldap
+- https://github.com/kvspb/nginx-auth-ldap
+maintainers:
+- name: rendhalver
+  email: pete.brown@powerhrg.com
+- name: jar361
+  email: jrodgers@powerhrg.com
+home: https://github.com/nginxinc/nginx-ldap-auth

--- a/charts/nginx-ldapauth-proxy/templates/NOTES.txt
+++ b/charts/nginx-ldapauth-proxy/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http://{{ . }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "nginx-ldapauth-proxy.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "nginx-ldapauth-proxy.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "nginx-ldapauth-proxy.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "nginx-ldapauth-proxy.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort }}
+{{- end }}

--- a/charts/nginx-ldapauth-proxy/templates/_helpers.tpl
+++ b/charts/nginx-ldapauth-proxy/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nginx-ldapauth-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nginx-ldapauth-proxy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nginx-ldapauth-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/nginx-ldapauth-proxy/templates/configmap.yaml
+++ b/charts/nginx-ldapauth-proxy/templates/configmap.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nginx-ldapauth-proxy.fullname" . }}
+  labels:
+    app: {{ template "nginx-ldapauth-proxy.name" . }}
+    chart: {{ template "nginx-ldapauth-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data:
+  nginx.conf: |-
+    worker_processes 10;
+    worker_rlimit_nofile 16384;
+
+    events {
+        worker_connections 1024;
+    }
+
+    http {
+
+        upstream backend-server {
+            server {{ .Values.proxy.host}}:{{ .Values.proxy.port }};
+        }
+
+{{- if and .Values.proxy.ldapHost .Values.secrets.ldapBindPassword }}
+        ldap_server ldapserver {
+            url {{ .Values.proxy.protocol }}://{{ .Values.proxy.ldapHost }}:{{ .Values.proxy.ldapPort }}/{{ .Values.proxy.ldapDN }}?uid?sub?(&({{ .Values.proxy.ldapFilter}}));
+            binddn "{{ .Values.proxy.ldapBindDN }}";
+            binddn_passwd {{ .Values.secrets.ldapBindPassword }};
+            group_attribute {{ .Values.proxy.ldapGroup }};
+            group_attribute_is_dn on;
+        {{- range $require := .Values.proxy.requires }}
+            require group {{ $require.filter | quote }};
+        {{- end }}
+            require valid_user;
+            satisfy all;
+        }
+{{- end }}
+
+        server {
+
+            listen {{ .Values.service.internalPort }};
+            server_name ldapauth-proxy;
+
+            error_log /var/log/nginx/error.log debug;
+            access_log /var/log/nginx/access.log;
+
+            client_max_body_size 0;
+
+            chunked_transfer_encoding on;
+
+            location / {
+{{- if and .Values.proxy.ldapHost .Values.secrets.ldapBindPassword }}
+                auth_ldap "{{ .Values.proxy.authName }}";
+                auth_ldap_servers ldapserver;
+                proxy_pass                       {{ if .Values.proxy.enableHTTPS }}https{{ else }}http{{ end }}://backend-server;
+                proxy_set_header  Host           $http_host;   # required for docker client's sake
+                proxy_set_header  X-Real-IP      $remote_addr; # pass on real client's IP
+                {{- if and .Values.proxy.authUser .Values.secrets.authPass }}
+                proxy_set_header  Authorization  "Basic {{(printf "%s:%s" .Values.proxy.authUser .Values.secrets.authPass)|b64enc}}";
+                {{- else }}
+                proxy_set_header  Authorization  ""; # see https://github.com/dotcloud/docker-registry/issues/170
+                {{- end }}
+                proxy_read_timeout               900;
+{{- end }}
+            }
+
+            location /_ping {
+                auth_basic off;
+                root   /usr/share/nginx/html;
+                stub_status on;
+            }
+        }
+
+    }

--- a/charts/nginx-ldapauth-proxy/templates/deployment.yaml
+++ b/charts/nginx-ldapauth-proxy/templates/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "nginx-ldapauth-proxy.fullname" . }}
+  labels:
+    app: {{ template "nginx-ldapauth-proxy.name" . }}
+    chart: {{ template "nginx-ldapauth-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "nginx-ldapauth-proxy.name" . }}
+      release: {{ .Release.Name }}
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "nginx-ldapauth-proxy.name" . }}
+        release: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+    {{- if .Values.image.pullSecrets }}
+      {{- range $pullSecret := .Values.image.pullSecrets }}
+      imagePullSecrets:
+        - name: {{ $pullSecret }}
+      {{- end }}
+    {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- if and .Values.proxy.ldapHost .Values.secrets.ldapBindPassword }}
+          env:
+            - name: LDAP_BIND_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "nginx-ldapauth-proxy.fullname" . }}
+                  key: ldapBindPassword
+            {{- if .Values.secrets.authPass }}
+            - name: AUTH_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "nginx-ldapauth-proxy.fullname" . }}
+                  key: authPass
+            {{- end }}
+{{- end }}
+          ports:
+            - containerPort: {{ .Values.service.internalPort }}
+          livenessProbe:
+            httpGet:
+              path: /_ping
+              port: {{ .Values.service.internalPort }}
+          readinessProbe:
+            httpGet:
+              path: /_ping
+              port: {{ .Values.service.internalPort }}
+          volumeMounts:
+            - mountPath: /etc/nginx/nginx.conf
+              name: config
+              subPath: nginx.conf
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "nginx-ldapauth-proxy.fullname" . }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/nginx-ldapauth-proxy/templates/ingress.yaml
+++ b/charts/nginx-ldapauth-proxy/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "nginx-ldapauth-proxy.fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+{{- $pathType := .Values.ingress.pathType | default "ImplementationSpecific" -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "nginx-ldapauth-proxy.fullname" . }}
+  labels:
+    app: {{ template "nginx-ldapauth-proxy.name" . }}
+    chart: {{ template "nginx-ldapauth-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.className }}
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            pathType: {{ $pathType }}
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/charts/nginx-ldapauth-proxy/templates/secrets.yaml
+++ b/charts/nginx-ldapauth-proxy/templates/secrets.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.secrets.ldapBindPassword }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "nginx-ldapauth-proxy.fullname" . }}
+  labels:
+    app: {{ template "nginx-ldapauth-proxy.name" . }}
+    chart: {{ template "nginx-ldapauth-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  ldapBindPassword: {{ .Values.secrets.ldapBindPassword | b64enc | quote }}
+  {{- if .Values.secrets.authPass }}
+  authPass: {{ .Values.secrets.authPass | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/nginx-ldapauth-proxy/templates/service.yaml
+++ b/charts/nginx-ldapauth-proxy/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "nginx-ldapauth-proxy.fullname" . }}
+  labels:
+    app: {{ template "nginx-ldapauth-proxy.name" . }}
+    chart: {{ template "nginx-ldapauth-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "nginx-ldapauth-proxy.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/nginx-ldapauth-proxy/values.yaml
+++ b/charts/nginx-ldapauth-proxy/values.yaml
@@ -1,0 +1,67 @@
+# Default values for nginx-ldapauth-proxy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  repository: dweomer/nginx-auth-ldap
+  tag: 1.13.5-on-alpine-3.5
+  pullPolicy: IfNotPresent
+  # pullSecrets:
+   # - docker-secret
+service:
+  name: nginx-ldapauth
+  type: ClusterIP
+  externalPort: 443
+  internalPort: 80
+proxy:
+  enableHTTPS: false
+  protocol: "ldap"
+  port: 443
+  host: "kubernetes.default.svc.cluster.local"
+  authName: "Auth Required"
+  # authUser: username
+  ldapHost: ""
+  ldapPort: 389
+  ldapGroup: "memberUid"
+  ldapDN: "dc=example,dc=com"
+  ldapFilter: "objectClass=organizationalPerson"
+  ldapBindDN: "cn=auth,dc=example,dc=com"
+  requires:
+    - name: "authGroup"
+      filter: "cn=secret,ou=groups,dc=example,dc=com"
+secrets:
+  ldapBindPassword: ""
+  # authPass: password
+
+ingress:
+  enabled: false
+  className: nginx
+  pathType: ImplementationSpecific
+  # Used to create an Ingress record.
+  hosts:
+    - ldapauth-service.local
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
### PR Description
Extracted from https://github.com/helm/charts/tree/master/stable/nginx-ldapauth-proxy and added an option to [pass basic auth](https://github.com/powerhome/helm-charts/pull/19/files#diff-7b180d2b1f2bf523aa5370fac9c04fd9dce5fb7f9dde21bec12d732129bb2c49R59-R63). 

### Checklist

 - [ ] Have you reviewed and updated the chart default values if necessary?
 - [ ] Have you reviewed and updated the chart documentation if necessary?
 - [ ] Does your branch follow the naming convention of `{chartNameWithDashes}-v{versionString}-{optionalPatchVersion}`?
 - [x] Have you bumped the version in the chart's `Chart.yaml`?

### Tagged Releases
Please remember to make a tagged release after merging your PR that:

 - Has a tag name that matches your PR branch name (see above)
 - Has a description that summarizes the changes made

This makes it possible to use previous versions of the charts maintained here as new releases are published. Please see the release history of this repository for examples.
