### PR TITLE
Initial version of clusterapi-resources chart

### DIFF
--- a/charts/clusterapi-resources/.helmignore
+++ b/charts/clusterapi-resources/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/clusterapi-resources/Chart.yaml
+++ b/charts/clusterapi-resources/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: clusterapi-resources
+description: A Helm chart for creating CAPI and CAPV resources.
+maintainers:
+  - name: iblackman
+    email: igor.blackman@powerhrg.com
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version of clusterctl used as base to generate the templates
+appVersion: "1.8.3"

--- a/charts/clusterapi-resources/README.md
+++ b/charts/clusterapi-resources/README.md
@@ -1,0 +1,5 @@
+# clusterapi-resources
+Install a series of CAPI and CAPV resources necessary to create a Kubernetes cluster.
+
+## Configuration
+It allows a serie of customizations, take a look into the `values.yaml` file for more details.

--- a/charts/clusterapi-resources/templates/Cluster.yaml
+++ b/charts/clusterapi-resources/templates/Cluster.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: {{ .Values.cluster.name }}
+  name: {{ .Values.cluster.name }}
+spec:
+  clusterNetwork:
+    {{- toYaml .Values.cluster.network | nindent 4 }}
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: {{ .Values.cluster.name }}
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: VSphereCluster
+    name: {{ .Values.cluster.name }}

--- a/charts/clusterapi-resources/templates/Cluster.yaml
+++ b/charts/clusterapi-resources/templates/Cluster.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: {{ .Values.cluster.name }}
   name: {{ .Values.cluster.name }}
+  namespace: {{ $.Release.Namespace }}
 spec:
   clusterNetwork:
     {{- toYaml .Values.cluster.network | nindent 4 }}

--- a/charts/clusterapi-resources/templates/ClusterResourceSet.yaml
+++ b/charts/clusterapi-resources/templates/ClusterResourceSet.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: {{ .Values.cluster.name }}
+  name: {{ .Values.cluster.name }}-crs-0
+spec:
+  clusterSelector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ .Values.cluster.name }}
+  resources:
+  - kind: Secret
+    name: vsphere-config-secret
+  - kind: Secret
+    name: cloud-provider-vsphere-credentials
+{{- if .Values.vsphereCluster.csi.enabled }}
+  - kind: ConfigMap
+    name: csi-manifests
+{{- end }}
+{{- if .Values.vsphereCluster.cpi.enabled }}
+  - kind: ConfigMap
+    name: cpi-manifests
+  - kind: ConfigMap
+    name: cpi-manifests-cloud-config
+{{- end }}
+{{- range $md := .Values.extraResourcesConfigmaps }}
+  - kind: ConfigMap
+    name: {{ $md.name }}
+{{- end }}
+{{- range $s := .Values.extraResourcesSecrets }}
+  - kind: Secret
+    name: {{ $s.name }}
+{{- end }}

--- a/charts/clusterapi-resources/templates/ClusterResourceSet.yaml
+++ b/charts/clusterapi-resources/templates/ClusterResourceSet.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: {{ .Values.cluster.name }}
   name: {{ .Values.cluster.name }}-crs-0
+  namespace: {{ $.Release.Namespace }}
 spec:
   clusterSelector:
     matchLabels:

--- a/charts/clusterapi-resources/templates/ConfigMapBigipCtrlAS3.yaml
+++ b/charts/clusterapi-resources/templates/ConfigMapBigipCtrlAS3.yaml
@@ -4,6 +4,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: as3cm
+  namespace: {{ $.Release.Namespace }}
   labels:
     f5type: virtual-server
     as3: "true"

--- a/charts/clusterapi-resources/templates/ConfigMapBigipCtrlAS3.yaml
+++ b/charts/clusterapi-resources/templates/ConfigMapBigipCtrlAS3.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.bigipCtrlAS3.enabled }}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: as3cm
+  labels:
+    f5type: virtual-server
+    as3: "true"
+data:
+  template: |
+    {
+      "class": "AS3",
+      "declaration": {
+        "class": "ADC",
+        "schemaVersion": "3.51.0",
+        "label": "http",
+        "remark": "{{ .Values.cluster.name }} Template",
+        "{{ .Values.cluster.name }}": {
+          "class": "Tenant",
+          "as3": {
+            "class": "Application",
+            "template": "generic",
+            "webdev_{{ .Values.cluster.name }}_kubeapi_{{ .Values.bigipCtrlAS3.vs.port }}_vs": {
+              "class": "Service_L4",
+              "layer4": "tcp",
+              "profileL4": {
+                "bigip": "/Common/fastL4"
+              },
+              "snat": {
+                "bigip": "/Common/SNATPool"
+              },
+              "virtualPort": {{ .Values.bigipCtrlAS3.vs.port }},
+              "remark": "{{ .Values.cluster.name }} kubeapi vs",
+              "virtualAddresses": [
+                "{{ .Values.bigipCtrlAS3.vs.address }}"
+              ],
+              "pool": "{{ .Values.cluster.name }}_kubeapi_pool"
+            },
+            "{{ .Values.cluster.name }}_kubeapi_pool": {
+              "class": "Pool",
+              "monitors": [
+                {"bigip": "/Common/https_kubeapi_healthz"}
+              ],
+              "members": [
+                {
+                  "servicePort": {{ .Values.bigipCtrlAS3.pool.port }},
+                  "serverAddresses": {{ toJson .Values.bigipCtrlAS3.pool.members }}
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+{{- end }}

--- a/charts/clusterapi-resources/templates/ConfigMapsCPIManifests.yaml
+++ b/charts/clusterapi-resources/templates/ConfigMapsCPIManifests.yaml
@@ -1,0 +1,251 @@
+---
+apiVersion: v1
+data:
+  data: |-
+    ---
+    # Source: vsphere-cpi/templates/service-account.yaml
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: cloud-controller-manager
+      labels:
+        app: vsphere-cpi
+        vsphere-cpi-infra: service-account
+        component: cloud-controller-manager
+      namespace: kube-system
+    ---
+    # Source: vsphere-cpi/templates/role.yaml
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: cloud-controller-manager
+      labels:
+        app: vsphere-cpi
+        vsphere-cpi-infra: role
+        component: cloud-controller-manager
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - "*"
+      - apiGroups:
+          - ""
+        resources:
+          - nodes/status
+        verbs:
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - services
+        verbs:
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - services/status
+        verbs:
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - persistentvolumes
+        verbs:
+          - get
+          - list
+          - update
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - endpoints
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - secrets
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - "coordination.k8s.io"
+        resources:
+          - leases
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+    ---
+    # Source: vsphere-cpi/templates/daemonset.yaml
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: vsphere-cpi
+      labels:
+        app: vsphere-cpi
+        vsphere-cpi-infra: daemonset
+        component: cloud-controller-manager
+        tier: control-plane
+      namespace: kube-system
+      annotations:
+    spec:
+      selector:
+        matchLabels:
+          app: vsphere-cpi
+      updateStrategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: vsphere-cpi
+            component: cloud-controller-manager
+            tier: control-plane
+            release: release-name
+            vsphere-cpi-infra: daemonset
+        spec:
+          tolerations:
+            - effect: NoSchedule
+              key: node.cloudprovider.kubernetes.io/uninitialized
+              value: "true"
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/control-plane
+              operator: Exists
+            - effect: NoSchedule
+              key: node.kubernetes.io/not-ready
+              operator: Exists
+            - effect: NoExecute
+              key: CriticalAddonsOnly
+              operator: Exists
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+          securityContext:
+            fsGroup: 1001
+            runAsUser: 1001
+          serviceAccountName: cloud-controller-manager
+          hostNetwork: true
+          dnsPolicy: ClusterFirst
+          priorityClassName: system-node-critical
+          containers:
+          - name: vsphere-cpi
+            image: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
+            imagePullPolicy: IfNotPresent
+            args:
+              - --cloud-provider=vsphere
+              - --v=2
+              - --cloud-config=/etc/cloud/vsphere.conf
+            volumeMounts:
+              - mountPath: /etc/cloud
+                name: vsphere-config-volume
+                readOnly: true
+          volumes:
+            - name: vsphere-config-volume
+              configMap:
+                name: cloud-config
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        app: vsphere-cpi
+        component: cloud-controller-manager
+        vsphere-cpi-infra: role-binding
+      name: servicecatalog.k8s.io:apiserver-authentication-reader
+      namespace: kube-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: extension-apiserver-authentication-reader
+    subjects:
+    - apiGroup: ""
+      kind: ServiceAccount
+      name: cloud-controller-manager
+      namespace: kube-system
+    - apiGroup: ""
+      kind: User
+      name: cloud-controller-manager
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app: vsphere-cpi
+        component: cloud-controller-manager
+        vsphere-cpi-infra: cluster-role-binding
+      name: cloud-controller-manager
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: cloud-controller-manager
+    subjects:
+    - kind: ServiceAccount
+      name: cloud-controller-manager
+      namespace: kube-system
+    - kind: User
+      name: cloud-controller-manager
+kind: ConfigMap
+metadata:
+  name: cpi-manifests
+---
+apiVersion: v1
+data:
+  data: |
+    ---
+    apiVersion: v1
+    data:
+      vsphere.conf: |
+        global:
+          port: 443
+          secretName: cloud-provider-vsphere-credentials
+          secretNamespace: kube-system
+          thumbprint: ''
+          {{- if .Values.vsphereCluster.insecure }}
+          insecureFlag: true
+          {{- end }}
+        vcenter:
+          {{ .Values.vsphereCluster.server }}:
+            datacenters:
+            - '{{ .Values.vsphereCluster.datacenter }}'
+            server: '{{ .Values.vsphereCluster.server }}'
+    kind: ConfigMap
+    metadata:
+      name: cloud-config
+      namespace: kube-system
+kind: ConfigMap
+metadata:
+    name: cpi-manifests-cloud-config

--- a/charts/clusterapi-resources/templates/ConfigMapsCPIManifests.yaml
+++ b/charts/clusterapi-resources/templates/ConfigMapsCPIManifests.yaml
@@ -221,6 +221,7 @@ data:
 kind: ConfigMap
 metadata:
   name: cpi-manifests
+  namespace: {{ $.Release.Namespace }}
 ---
 apiVersion: v1
 data:
@@ -248,4 +249,5 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-    name: cpi-manifests-cloud-config
+  name: cpi-manifests-cloud-config
+  namespace: {{ $.Release.Namespace }}

--- a/charts/clusterapi-resources/templates/ConfigMapsCSIManifests.yaml
+++ b/charts/clusterapi-resources/templates/ConfigMapsCSIManifests.yaml
@@ -1,0 +1,848 @@
+---
+apiVersion: v1
+data:
+  data: |-
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: vmware-system-csi
+    ---
+    apiVersion: storage.k8s.io/v1
+    kind: CSIDriver
+    metadata:
+      name: csi.vsphere.vmware.com
+    spec:
+      attachRequired: true
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: vsphere-csi-controller
+      namespace: vmware-system-csi
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: vsphere-csi-controller-role
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+    - apiGroups:
+      - ""
+      resources:
+      - persistentvolumeclaims
+      verbs:
+      - get
+      - list
+      - watch
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - persistentvolumeclaims/status
+      verbs:
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - persistentvolumes
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create
+    - apiGroups:
+      - storage.k8s.io
+      resources:
+      - storageclasses
+      - csinodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - storage.k8s.io
+      resources:
+      - volumeattachments
+      verbs:
+      - get
+      - list
+      - watch
+      - patch
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - triggercsifullsyncs
+      verbs:
+      - create
+      - get
+      - update
+      - watch
+      - list
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - cnsvspherevolumemigrations
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - delete
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - cnsvolumeinfoes
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - delete
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - customresourcedefinitions
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
+      - storage.k8s.io
+      resources:
+      - volumeattachments/status
+      verbs:
+      - patch
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - cnsvolumeoperationrequests
+      verbs:
+      - create
+      - get
+      - list
+      - update
+      - delete
+    - apiGroups:
+      - snapshot.storage.k8s.io
+      resources:
+      - volumesnapshots
+      verbs:
+      - get
+      - list
+    - apiGroups:
+      - snapshot.storage.k8s.io
+      resources:
+      - volumesnapshotclasses
+      verbs:
+      - watch
+      - get
+      - list
+    - apiGroups:
+      - snapshot.storage.k8s.io
+      resources:
+      - volumesnapshotcontents
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - delete
+      - patch
+    - apiGroups:
+      - snapshot.storage.k8s.io
+      resources:
+      - volumesnapshotcontents/status
+      verbs:
+      - update
+      - patch
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - csinodetopologies
+      verbs:
+      - get
+      - update
+      - watch
+      - list
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: vsphere-csi-controller-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: vsphere-csi-controller-role
+    subjects:
+    - kind: ServiceAccount
+      name: vsphere-csi-controller
+      namespace: vmware-system-csi
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: vsphere-csi-node
+      namespace: vmware-system-csi
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: vsphere-csi-node-cluster-role
+    rules:
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - csinodetopologies
+      verbs:
+      - create
+      - watch
+      - get
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: vsphere-csi-node-cluster-role-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: vsphere-csi-node-cluster-role
+    subjects:
+    - kind: ServiceAccount
+      name: vsphere-csi-node
+      namespace: vmware-system-csi
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: vsphere-csi-node-role
+      namespace: vmware-system-csi
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: vsphere-csi-node-binding
+      namespace: vmware-system-csi
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: vsphere-csi-node-role
+    subjects:
+    - kind: ServiceAccount
+      name: vsphere-csi-node
+      namespace: vmware-system-csi
+    ---
+    apiVersion: v1
+    data:
+      pv-to-backingdiskobjectid-mapping: "false"
+      trigger-csi-fullsync: "false"
+    kind: ConfigMap
+    metadata:
+      name: internal-feature-states.csi.vsphere.vmware.com
+      namespace: vmware-system-csi
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: vsphere-csi-controller
+      name: vsphere-csi-controller
+      namespace: vmware-system-csi
+    spec:
+      ports:
+      - name: ctlr
+        port: 2112
+        protocol: TCP
+        targetPort: 2112
+      - name: syncer
+        port: 2113
+        protocol: TCP
+        targetPort: 2113
+      selector:
+        app: vsphere-csi-controller
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: vsphere-csi-controller
+      namespace: vmware-system-csi
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: vsphere-csi-controller
+      strategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: vsphere-csi-controller
+            role: vsphere-csi
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                - matchExpressions:
+                  - key: node-role.kubernetes.io/controlplane
+                    operator: Exists
+                - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - vsphere-csi-controller
+                topologyKey: kubernetes.io/hostname
+          containers:
+          - args:
+            - --v=4
+            - --timeout=300s
+            - --csi-address=$(ADDRESS)
+            - --leader-election
+            - --leader-election-lease-duration=120s
+            - --leader-election-renew-deadline=60s
+            - --leader-election-retry-period=30s
+            - --kube-api-qps=100
+            - --kube-api-burst=100
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            image: registry.k8s.io/sig-storage/csi-attacher:v4.5.1
+            name: csi-attacher
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          - args:
+            - --v=4
+            - --timeout=300s
+            - --handle-volume-inuse-error=false
+            - --csi-address=$(ADDRESS)
+            - --kube-api-qps=100
+            - --kube-api-burst=100
+            - --leader-election
+            - --leader-election-lease-duration=120s
+            - --leader-election-renew-deadline=60s
+            - --leader-election-retry-period=30s
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            image: registry.k8s.io/sig-storage/csi-resizer:v1.10.1
+            name: csi-resizer
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          - args:
+            - --fss-name=internal-feature-states.csi.vsphere.vmware.com
+            - --fss-namespace=$(CSI_NAMESPACE)
+            env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: X_CSI_MODE
+              value: controller
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
+            - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
+              value: 3m
+            - name: VSPHERE_CSI_CONFIG
+              value: /etc/cloud/csi-vsphere.conf
+            - name: LOGGER_LEVEL
+              value: PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: registry.k8s.io/csi-vsphere/driver:v3.3.1
+            imagePullPolicy: Always
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 30
+              periodSeconds: 180
+              timeoutSeconds: 10
+            name: vsphere-csi-controller
+            ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+            - containerPort: 2112
+              name: prometheus
+              protocol: TCP
+            securityContext:
+              runAsGroup: 65532
+              runAsNonRoot: true
+              runAsUser: 65532
+            volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /csi
+              name: socket-dir
+          - args:
+            - --v=4
+            - --csi-address=/csi/csi.sock
+            image: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
+            name: liveness-probe
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          - args:
+            - --leader-election
+            - --leader-election-lease-duration=30s
+            - --leader-election-renew-deadline=20s
+            - --leader-election-retry-period=10s
+            - --fss-name=internal-feature-states.csi.vsphere.vmware.com
+            - --fss-namespace=$(CSI_NAMESPACE)
+            env:
+            - name: FULL_SYNC_INTERVAL_MINUTES
+              value: "30"
+            - name: VSPHERE_CSI_CONFIG
+              value: /etc/cloud/csi-vsphere.conf
+            - name: LOGGER_LEVEL
+              value: PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: registry.k8s.io/csi-vsphere/syncer:v3.3.1
+            imagePullPolicy: Always
+            name: vsphere-syncer
+            ports:
+            - containerPort: 2113
+              name: prometheus
+              protocol: TCP
+            securityContext:
+              runAsGroup: 65532
+              runAsNonRoot: true
+              runAsUser: 65532
+            volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+          - args:
+            - --v=4
+            - --timeout=300s
+            - --csi-address=$(ADDRESS)
+            - --kube-api-qps=100
+            - --kube-api-burst=100
+            - --leader-election
+            - --leader-election-lease-duration=120s
+            - --leader-election-renew-deadline=60s
+            - --leader-election-retry-period=30s
+            - --default-fstype=ext4
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.1
+            name: csi-provisioner
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          - args:
+            - --v=4
+            - --kube-api-qps=100
+            - --kube-api-burst=100
+            - --timeout=300s
+            - --csi-address=$(ADDRESS)
+            - --leader-election
+            - --leader-election-lease-duration=120s
+            - --leader-election-renew-deadline=60s
+            - --leader-election-retry-period=30s
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            image: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.2
+            name: csi-snapshotter
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          dnsPolicy: Default
+          priorityClassName: system-cluster-critical
+          serviceAccountName: vsphere-csi-controller
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
+          volumes:
+          - name: vsphere-config-volume
+            secret:
+              secretName: vsphere-config-secret
+          - emptyDir: {}
+            name: socket-dir
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: vsphere-csi-node
+      namespace: vmware-system-csi
+    spec:
+      selector:
+        matchLabels:
+          app: vsphere-csi-node
+      template:
+        metadata:
+          labels:
+            app: vsphere-csi-node
+            role: vsphere-csi
+        spec:
+          containers:
+          - args:
+            - --v=5
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+            image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
+            livenessProbe:
+              exec:
+                command:
+                - /csi-node-driver-registrar
+                - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+                - --mode=kubelet-registration-probe
+              initialDelaySeconds: 3
+            name: node-driver-registrar
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+            - mountPath: /registration
+              name: registration-dir
+          - args:
+            - --fss-name=internal-feature-states.csi.vsphere.vmware.com
+            - --fss-namespace=$(CSI_NAMESPACE)
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: MAX_VOLUMES_PER_NODE
+              value: "59"
+            - name: X_CSI_MODE
+              value: node
+            - name: X_CSI_SPEC_REQ_VALIDATION
+              value: "false"
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
+            - name: LOGGER_LEVEL
+              value: PRODUCTION
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODEGETINFO_WATCH_TIMEOUT_MINUTES
+              value: "1"
+            image: registry.k8s.io/csi-vsphere/driver:v3.3.1
+            imagePullPolicy: Always
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              timeoutSeconds: 5
+            name: vsphere-csi-node
+            ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+            securityContext:
+              allowPrivilegeEscalation: true
+              capabilities:
+                add:
+                - SYS_ADMIN
+              privileged: true
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+            - mountPath: /var/lib/kubelet
+              mountPropagation: Bidirectional
+              name: pods-mount-dir
+            - mountPath: /dev
+              name: device-dir
+            - mountPath: /sys/block
+              name: blocks-dir
+            - mountPath: /sys/devices
+              name: sys-devices-dir
+          - args:
+            - --v=4
+            - --csi-address=/csi/csi.sock
+            image: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
+            name: liveness-probe
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+          dnsPolicy: ClusterFirstWithHostNet
+          hostNetwork: true
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: vsphere-csi-node
+          tolerations:
+          - effect: NoExecute
+            operator: Exists
+          - effect: NoSchedule
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: /var/lib/kubelet/plugins_registry
+              type: Directory
+            name: registration-dir
+          - hostPath:
+              path: /var/lib/kubelet/plugins/csi.vsphere.vmware.com
+              type: DirectoryOrCreate
+            name: plugin-dir
+          - hostPath:
+              path: /var/lib/kubelet
+              type: Directory
+            name: pods-mount-dir
+          - hostPath:
+              path: /dev
+            name: device-dir
+          - hostPath:
+              path: /sys/block
+              type: Directory
+            name: blocks-dir
+          - hostPath:
+              path: /sys/devices
+              type: Directory
+            name: sys-devices-dir
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: vsphere-csi-node-windows
+      namespace: vmware-system-csi
+    spec:
+      selector:
+        matchLabels:
+          app: vsphere-csi-node-windows
+      template:
+        metadata:
+          labels:
+            app: vsphere-csi-node-windows
+            role: vsphere-csi-windows
+        spec:
+          containers:
+          - args:
+            - --v=5
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            env:
+            - name: ADDRESS
+              value: unix://C:\\csi\\csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: C:\\var\\lib\\kubelet\\plugins\\csi.vsphere.vmware.com\\csi.sock
+            image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
+            livenessProbe:
+              exec:
+                command:
+                - /csi-node-driver-registrar.exe
+                - --kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\csi.vsphere.vmware.com\\csi.sock
+                - --mode=kubelet-registration-probe
+              initialDelaySeconds: 3
+            name: node-driver-registrar
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+            - mountPath: /registration
+              name: registration-dir
+          - args:
+            - --fss-name=internal-feature-states.csi.vsphere.vmware.com
+            - --fss-namespace=$(CSI_NAMESPACE)
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix://C:\\csi\\csi.sock
+            - name: MAX_VOLUMES_PER_NODE
+              value: "59"
+            - name: X_CSI_MODE
+              value: node
+            - name: X_CSI_SPEC_REQ_VALIDATION
+              value: "false"
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
+            - name: LOGGER_LEVEL
+              value: PRODUCTION
+            - name: X_CSI_LOG_LEVEL
+              value: DEBUG
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODEGETINFO_WATCH_TIMEOUT_MINUTES
+              value: "1"
+            image: registry.k8s.io/csi-vsphere/driver:v3.3.1
+            imagePullPolicy: Always
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              timeoutSeconds: 5
+            name: vsphere-csi-node
+            ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+            volumeMounts:
+            - mountPath: C:\csi
+              name: plugin-dir
+            - mountPath: C:\var\lib\kubelet
+              name: pods-mount-dir
+            - mountPath: \\.\pipe\csi-proxy-volume-v1
+              name: csi-proxy-volume-v1
+            - mountPath: \\.\pipe\csi-proxy-filesystem-v1
+              name: csi-proxy-filesystem-v1
+            - mountPath: \\.\pipe\csi-proxy-disk-v1
+              name: csi-proxy-disk-v1
+            - mountPath: \\.\pipe\csi-proxy-system-v1alpha1
+              name: csi-proxy-system-v1alpha1
+          - args:
+            - --v=4
+            - --csi-address=/csi/csi.sock
+            image: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
+            name: liveness-probe
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+          nodeSelector:
+            kubernetes.io/os: windows
+          priorityClassName: system-node-critical
+          serviceAccountName: vsphere-csi-node
+          tolerations:
+          - effect: NoExecute
+            operator: Exists
+          - effect: NoSchedule
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: C:\var\lib\kubelet\plugins_registry\
+              type: Directory
+            name: registration-dir
+          - hostPath:
+              path: C:\var\lib\kubelet\plugins\csi.vsphere.vmware.com\
+              type: DirectoryOrCreate
+            name: plugin-dir
+          - hostPath:
+              path: \var\lib\kubelet
+              type: Directory
+            name: pods-mount-dir
+          - hostPath:
+              path: \\.\pipe\csi-proxy-disk-v1
+              type: ""
+            name: csi-proxy-disk-v1
+          - hostPath:
+              path: \\.\pipe\csi-proxy-volume-v1
+              type: ""
+            name: csi-proxy-volume-v1
+          - hostPath:
+              path: \\.\pipe\csi-proxy-filesystem-v1
+              type: ""
+            name: csi-proxy-filesystem-v1
+          - hostPath:
+              path: \\.\pipe\csi-proxy-system-v1alpha1
+              type: ""
+            name: csi-proxy-system-v1alpha1
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
+kind: ConfigMap
+metadata:
+  name: csi-manifests

--- a/charts/clusterapi-resources/templates/ConfigMapsCSIManifests.yaml
+++ b/charts/clusterapi-resources/templates/ConfigMapsCSIManifests.yaml
@@ -846,3 +846,4 @@ data:
 kind: ConfigMap
 metadata:
   name: csi-manifests
+  namespace: {{ $.Release.Namespace }}

--- a/charts/clusterapi-resources/templates/ConfigMapsExtra.yaml
+++ b/charts/clusterapi-resources/templates/ConfigMapsExtra.yaml
@@ -8,5 +8,6 @@ data:
 kind: ConfigMap
 metadata:
   name: {{ $cm.name }}
+  namespace: {{ $.Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/charts/clusterapi-resources/templates/ConfigMapsExtra.yaml
+++ b/charts/clusterapi-resources/templates/ConfigMapsExtra.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.extraResourcesConfigmaps }}
+{{- range $cm := .Values.extraResourcesConfigmaps }}
+---
+apiVersion: v1
+data:
+  data: |-
+    {{- $cm.data | nindent 4 }}
+kind: ConfigMap
+metadata:
+  name: {{ $cm.name }}
+{{- end }}
+{{- end }}

--- a/charts/clusterapi-resources/templates/InClusterIPPool.yaml
+++ b/charts/clusterapi-resources/templates/InClusterIPPool.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.inClusterIPPool }}
+{{- range $pool := .Values.inClusterIPPool }}
+---
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: {{ $pool.name }}
+spec:
+  {{- toYaml $pool.spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/clusterapi-resources/templates/InClusterIPPool.yaml
+++ b/charts/clusterapi-resources/templates/InClusterIPPool.yaml
@@ -5,6 +5,7 @@ apiVersion: ipam.cluster.x-k8s.io/v1alpha2
 kind: InClusterIPPool
 metadata:
   name: {{ $pool.name }}
+  namespace: {{ $.Release.Namespace }}
 spec:
   {{- toYaml $pool.spec | nindent 2 }}
 {{- end }}

--- a/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
+++ b/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
@@ -1,11 +1,11 @@
-{{- $values := .Values }}
 {{- if .Values.machineDeployments }}
 {{- range $md := .Values.machineDeployments }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: {{ $values.cluster.name }}-{{ $md.name}}
+  name: {{ $.Values.cluster.name }}-{{ $md.name}}
+  namespace: {{ $.Release.Namespace }}
 spec:
   template:
     spec:
@@ -15,16 +15,16 @@ spec:
           kubeletExtraArgs:
             cloud-provider: external
           name: '{{`{{ local_hostname }}`}}'
-{{- with $values.kubeadmConfigSpec.files }}
+{{- with $.Values.kubeadmConfigSpec.files }}
       files:
       {{- toYaml . | nindent 6 }}
 {{- end }}
       preKubeadmCommands:
-      {{- toYaml $values.kubeadmConfigSpec.preKubeadmCommands | nindent 6 }}
+      {{- toYaml $.Values.kubeadmConfigSpec.preKubeadmCommands | nindent 6 }}
       users:
       - name: capv
         sshAuthorizedKeys:
-        {{- toYaml $values.kubeadmConfigSpec.sshAuthorizedKeys | nindent 8 }}
+        {{- toYaml $.Values.kubeadmConfigSpec.sshAuthorizedKeys | nindent 8 }}
         sudo: ALL=(ALL) NOPASSWD:ALL
 {{- end }}
 {{- end }}

--- a/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
+++ b/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
@@ -1,0 +1,30 @@
+{{- $values := .Values }}
+{{- if .Values.machineDeployments }}
+{{- range $md := .Values.machineDeployments }}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: {{ $values.cluster.name }}-{{ $md.name}}
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          kubeletExtraArgs:
+            cloud-provider: external
+          name: '{{`{{ local_hostname }}`}}'
+{{- with $values.kubeadmConfigSpec.files }}
+      files:
+      {{- toYaml . | nindent 6 }}
+{{- end }}
+      preKubeadmCommands:
+      {{- toYaml $values.kubeadmConfigSpec.preKubeadmCommands | nindent 6 }}
+      users:
+      - name: capv
+        sshAuthorizedKeys:
+        {{- toYaml $values.kubeadmConfigSpec.sshAuthorizedKeys | nindent 8 }}
+        sudo: ALL=(ALL) NOPASSWD:ALL
+{{- end }}
+{{- end }}

--- a/charts/clusterapi-resources/templates/KubeadmControlPlane.yaml
+++ b/charts/clusterapi-resources/templates/KubeadmControlPlane.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: {{ .Values.cluster.name }}
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        extraArgs:
+          cloud-provider: external
+      controllerManager:
+        extraArgs:
+          cloud-provider: external
+{{- with .Values.kubeadmConfigSpec.files }}
+    files:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+    initConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          cloud-provider: external
+        name: '{{`{{ local_hostname }}`}}'
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          cloud-provider: external
+        name: '{{`{{ local_hostname }}`}}'
+    preKubeadmCommands:
+    {{- toYaml .Values.kubeadmConfigSpec.preKubeadmCommands | nindent 4 }}
+    users:
+    - name: capv
+      sshAuthorizedKeys:
+      {{- toYaml .Values.kubeadmConfigSpec.sshAuthorizedKeys | nindent 6 }}
+      sudo: ALL=(ALL) NOPASSWD:ALL
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: VSphereMachineTemplate
+      name: {{ .Values.kubeadmControlPlane.template }}
+  replicas: {{ .Values.kubeadmControlPlane.replicas }}
+  version: {{ .Values.kubeadmControlPlane.version }}

--- a/charts/clusterapi-resources/templates/KubeadmControlPlane.yaml
+++ b/charts/clusterapi-resources/templates/KubeadmControlPlane.yaml
@@ -3,6 +3,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
   name: {{ .Values.cluster.name }}
+  namespace: {{ $.Release.Namespace }}
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:

--- a/charts/clusterapi-resources/templates/MachineDeployment.yaml
+++ b/charts/clusterapi-resources/templates/MachineDeployment.yaml
@@ -1,0 +1,33 @@
+{{- $values := .Values }}
+{{- if .Values.machineDeployments }}
+{{- range $md := .Values.machineDeployments }}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: {{ $values.cluster.name }}
+  name: {{ $values.cluster.name }}-{{ $md.name }}
+spec:
+  clusterName: {{ $values.cluster.name }}
+  replicas: {{ $md.replicas }}
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: {{ $values.cluster.name }}
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: {{ $values.cluster.name }}-{{ $md.name }}
+      clusterName: {{ $values.cluster.name }}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        name: {{ $md.template }}
+      version: {{ $md.version }}
+{{- end }}
+{{- end }}

--- a/charts/clusterapi-resources/templates/MachineDeployment.yaml
+++ b/charts/clusterapi-resources/templates/MachineDeployment.yaml
@@ -1,4 +1,3 @@
-{{- $values := .Values }}
 {{- if .Values.machineDeployments }}
 {{- range $md := .Values.machineDeployments }}
 ---
@@ -6,24 +5,25 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: {{ $values.cluster.name }}
-  name: {{ $values.cluster.name }}-{{ $md.name }}
+    cluster.x-k8s.io/cluster-name: {{ $.Values.cluster.name }}
+  name: {{ $.Values.cluster.name }}-{{ $md.name }}
+  namespace: {{ $.Release.Namespace }}
 spec:
-  clusterName: {{ $values.cluster.name }}
+  clusterName: {{ $.Values.cluster.name }}
   replicas: {{ $md.replicas }}
   selector:
     matchLabels: {}
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: {{ $values.cluster.name }}
+        cluster.x-k8s.io/cluster-name: {{ $.Values.cluster.name }}
     spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: {{ $values.cluster.name }}-{{ $md.name }}
-      clusterName: {{ $values.cluster.name }}
+          name: {{ $.Values.cluster.name }}-{{ $md.name }}
+      clusterName: {{ $.Values.cluster.name }}
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: VSphereMachineTemplate

--- a/charts/clusterapi-resources/templates/NOTES.txt
+++ b/charts/clusterapi-resources/templates/NOTES.txt
@@ -1,0 +1,13 @@
+{{- $values := .Values}}
+Cluster {{ .Values.cluster.name }} deployed.
+- Control plane endpoint: {{ .Values.vsphereCluster.controlPlaneEndpoint.host }}:{{ .Values.vsphereCluster.controlPlaneEndpoint.port }}
+- Control Plane
+  - replicas: {{ .Values.kubeadmControlPlane.replicas }}
+  - template: {{ .Values.kubeadmControlPlane.template }}
+  - version: {{ .Values.kubeadmControlPlane.version }}
+{{- range $md := .Values.machineDeployments }}
+- Workers {{ $values.cluster.name }}-{{ $md.name }}
+  - replicas: {{ $md.replicas }}
+  - template: {{ $md.template }}
+  - version: {{ $md.version }}
+{{- end }}

--- a/charts/clusterapi-resources/templates/NOTES.txt
+++ b/charts/clusterapi-resources/templates/NOTES.txt
@@ -1,4 +1,3 @@
-{{- $values := .Values}}
 Cluster {{ .Values.cluster.name }} deployed.
 - Control plane endpoint: {{ .Values.vsphereCluster.controlPlaneEndpoint.host }}:{{ .Values.vsphereCluster.controlPlaneEndpoint.port }}
 - Control Plane
@@ -6,7 +5,7 @@ Cluster {{ .Values.cluster.name }} deployed.
   - template: {{ .Values.kubeadmControlPlane.template }}
   - version: {{ .Values.kubeadmControlPlane.version }}
 {{- range $md := .Values.machineDeployments }}
-- Workers {{ $values.cluster.name }}-{{ $md.name }}
+- Workers {{ $.Values.cluster.name }}-{{ $md.name }}
   - replicas: {{ $md.replicas }}
   - template: {{ $md.template }}
   - version: {{ $md.version }}

--- a/charts/clusterapi-resources/templates/Secrets.yaml
+++ b/charts/clusterapi-resources/templates/Secrets.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.cluster.name }}
+stringData:
+  password: {{ .Values.vsphereCluster.password }}
+  username: {{ .Values.vsphereCluster.username }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-config-secret
+stringData:
+  data: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: vsphere-config-secret
+      namespace: vmware-system-csi
+    stringData:
+      csi-vsphere.conf: |+
+        [Global]
+        thumbprint = ""
+        {{- if .Values.vsphereCluster.insecure }}
+        insecure-flag = true
+        {{- end }}
+
+        [VirtualCenter "{{ .Values.vsphereCluster.server }}"]
+        user = "{{ .Values.vsphereCluster.username }}"
+        password = "{{ .Values.vsphereCluster.password }}"
+        datacenters = "{{ .Values.vsphereCluster.datacenter }}"
+
+        [Network]
+        public-network = "{{ .Values.vsphereCluster.publicNetwork }}"
+
+    type: Opaque
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-provider-vsphere-credentials
+stringData:
+  data: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        component: cloud-controller-manager
+        vsphere-cpi-infra: secret
+      name: cloud-provider-vsphere-credentials
+      namespace: kube-system
+    stringData:
+      {{ .Values.vsphereCluster.server }}.password: {{ .Values.vsphereCluster.password }}
+      {{ .Values.vsphereCluster.server }}.username: {{ .Values.vsphereCluster.username }}
+    type: Opaque
+type: addons.cluster.x-k8s.io/resource-set

--- a/charts/clusterapi-resources/templates/Secrets.yaml
+++ b/charts/clusterapi-resources/templates/Secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.cluster.name }}
+  namespace: {{ $.Release.Namespace }}
 stringData:
   password: {{ .Values.vsphereCluster.password }}
   username: {{ .Values.vsphereCluster.username }}
@@ -11,6 +12,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: vsphere-config-secret
+  namespace: {{ $.Release.Namespace }}
 stringData:
   data: |
     apiVersion: v1
@@ -41,6 +43,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloud-provider-vsphere-credentials
+  namespace: {{ $.Release.Namespace }}
 stringData:
   data: |
     apiVersion: v1

--- a/charts/clusterapi-resources/templates/SecretsExtra.yaml
+++ b/charts/clusterapi-resources/templates/SecretsExtra.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.extraResourcesSecrets }}
+{{- range $s := .Values.extraResourcesSecrets }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $s.name }}
+stringData:
+  data: |
+    {{- $s.data | nindent 4 }}
+type: addons.cluster.x-k8s.io/resource-set
+{{- end }}
+{{- end }}

--- a/charts/clusterapi-resources/templates/SecretsExtra.yaml
+++ b/charts/clusterapi-resources/templates/SecretsExtra.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $s.name }}
+  namespace: {{ $.Release.Namespace }}
 stringData:
   data: |
     {{- $s.data | nindent 4 }}

--- a/charts/clusterapi-resources/templates/VSphereCluster.yaml
+++ b/charts/clusterapi-resources/templates/VSphereCluster.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereCluster
+metadata:
+  name: {{ .Values.cluster.name }}
+spec:
+  controlPlaneEndpoint:
+    host: {{ .Values.vsphereCluster.controlPlaneEndpoint.host }}
+    port: {{ .Values.vsphereCluster.controlPlaneEndpoint.port }}
+  identityRef:
+    kind: Secret
+    name: {{ .Values.cluster.name }}
+  server: {{ .Values.vsphereCluster.server }}
+  thumbprint: "{{ .Values.vsphereCluster.thumbprint }}"

--- a/charts/clusterapi-resources/templates/VSphereCluster.yaml
+++ b/charts/clusterapi-resources/templates/VSphereCluster.yaml
@@ -3,6 +3,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster
 metadata:
   name: {{ .Values.cluster.name }}
+  namespace: {{ $.Release.Namespace }}
 spec:
   controlPlaneEndpoint:
     host: {{ .Values.vsphereCluster.controlPlaneEndpoint.host }}

--- a/charts/clusterapi-resources/templates/VSphereMachineTemplate.yaml
+++ b/charts/clusterapi-resources/templates/VSphereMachineTemplate.yaml
@@ -1,0 +1,30 @@
+{{- $values := .Values }}
+{{- $defaultSpec := .Values.vsphereMachineTemplate.defaults.spec }}
+{{- if .Values.vsphereMachineTemplate.templates }}
+{{- range $t := .Values.vsphereMachineTemplate.templates }}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: {{ $t.name }}
+spec:
+  template:
+    spec:
+      cloneMode: {{ $t.spec.cloneMode | default $defaultSpec.cloneMode }}
+      datacenter: {{ $t.spec.datacenter | default $values.vsphereCluster.datacenter }}
+      datastore: {{ $t.spec.datastore | default $defaultSpec.datastore }}
+      diskGiB: {{ $t.spec.diskGiB | default $defaultSpec.diskGiB }}
+      folder: {{ $t.spec.folder | default $defaultSpec.folder }}
+      memoryMiB: {{ $t.spec.memoryMiB | default $defaultSpec.memoryMiB }}
+      network:
+        {{- toYaml ($t.spec.network | default $defaultSpec.network) | nindent 8 }}
+      numCPUs: {{ $t.spec.numCPUs | default $defaultSpec.numCPUs }}
+      os: {{ $t.spec.os | default $defaultSpec.os }}
+      powerOffMode: {{ $t.spec.powerOffMode | default $defaultSpec.powerOffMode }}
+      resourcePool: {{ $t.spec.resourcePool | default $defaultSpec.resourcePool }}
+      server: {{ $t.spec.server | default $values.vsphereCluster.server }}
+      storagePolicyName: "{{ $t.spec.storagePolicyName | default $defaultSpec.storagePolicyName }}"
+      template: {{ $t.spec.template | default $defaultSpec.template }}
+      thumbprint: "{{ $t.spec.thumbprint | default $values.vsphereCluster.thumbprint }}"
+{{- end }}
+{{- end }}

--- a/charts/clusterapi-resources/templates/VSphereMachineTemplate.yaml
+++ b/charts/clusterapi-resources/templates/VSphereMachineTemplate.yaml
@@ -1,4 +1,3 @@
-{{- $values := .Values }}
 {{- $defaultSpec := .Values.vsphereMachineTemplate.defaults.spec }}
 {{- if .Values.vsphereMachineTemplate.templates }}
 {{- range $t := .Values.vsphereMachineTemplate.templates }}
@@ -7,11 +6,12 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
 metadata:
   name: {{ $t.name }}
+  namespace: {{ $.Release.Namespace }}
 spec:
   template:
     spec:
       cloneMode: {{ $t.spec.cloneMode | default $defaultSpec.cloneMode }}
-      datacenter: {{ $t.spec.datacenter | default $values.vsphereCluster.datacenter }}
+      datacenter: {{ $t.spec.datacenter | default $.Values.vsphereCluster.datacenter }}
       datastore: {{ $t.spec.datastore | default $defaultSpec.datastore }}
       diskGiB: {{ $t.spec.diskGiB | default $defaultSpec.diskGiB }}
       folder: {{ $t.spec.folder | default $defaultSpec.folder }}
@@ -22,9 +22,9 @@ spec:
       os: {{ $t.spec.os | default $defaultSpec.os }}
       powerOffMode: {{ $t.spec.powerOffMode | default $defaultSpec.powerOffMode }}
       resourcePool: {{ $t.spec.resourcePool | default $defaultSpec.resourcePool }}
-      server: {{ $t.spec.server | default $values.vsphereCluster.server }}
+      server: {{ $t.spec.server | default $.Values.vsphereCluster.server }}
       storagePolicyName: "{{ $t.spec.storagePolicyName | default $defaultSpec.storagePolicyName }}"
       template: {{ $t.spec.template | default $defaultSpec.template }}
-      thumbprint: "{{ $t.spec.thumbprint | default $values.vsphereCluster.thumbprint }}"
+      thumbprint: "{{ $t.spec.thumbprint | default $.Values.vsphereCluster.thumbprint }}"
 {{- end }}
 {{- end }}

--- a/charts/clusterapi-resources/templates/_helpers.tpl
+++ b/charts/clusterapi-resources/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "clusterapi-resources.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "clusterapi-resources.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "clusterapi-resources.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "clusterapi-resources.labels" -}}
+helm.sh/chart: {{ include "clusterapi-resources.chart" . }}
+{{ include "clusterapi-resources.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "clusterapi-resources.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "clusterapi-resources.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "clusterapi-resources.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "clusterapi-resources.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/clusterapi-resources/values.yaml
+++ b/charts/clusterapi-resources/values.yaml
@@ -1,0 +1,139 @@
+# Default values for clusterapi-resources.
+# This is a YAML-formatted file.
+
+cluster:
+  name: cluster
+  network:
+    pods:
+      cidrBlocks:
+      - 10.68.0.0/19
+    services:
+      cidrBlocks:
+      - 10.68.32.0/19
+
+vsphereCluster:
+  controlPlaneEndpoint:
+    host: kubeapi.domain.com
+    port: 6443
+  server: vcenter.address
+  thumbprint: ""
+  username: username
+  password: password
+  datacenter: DATACENTER
+  publicNetwork: network
+  insecure: true
+  csi:
+    enabled: true
+  cpi:
+    enabled: true
+
+vsphereMachineTemplate:
+  defaults:
+    spec:
+      cloneMode: linkedClone
+      datastore: DATASTORE
+      diskGiB: 50
+      folder: FOLDER
+      memoryMiB: 8192
+      network:
+        devices:
+        - addressesFromPools:
+          - apiGroup: ipam.cluster.x-k8s.io
+            kind: InClusterIPPool
+            name: control-plane-pool
+          nameservers:
+          - 10.1.12.153
+          - 10.0.12.153
+          networkName: 160_FOLDER
+      numCPUs: 4
+      os: Linux
+      powerOffMode: trySoft
+      resourcePool: /DATACENTER/host/HQ-Cluster/Resources/PAC/Prod
+      storagePolicyName: ""
+      template: ubuntu-2204-kube-v1.30.0
+  # list of VSphereMachineTemplates to be created overriding the defaults above if desired
+  templates: []
+  # - name: template-name
+  #   spec:
+  #     diskGiB: 50
+  #     memoryMiB: 8192
+  #     network:
+  #       devices:
+  #       - dhcp4: true
+  #         mtu: 9000
+  #         networkName: 225_iSCSI
+  #     numCPUs: 4
+  #     template: ubuntu-2204-kube-v1.30.0
+
+kubeadmConfigSpec:
+  preKubeadmCommands:
+  - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+  - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6" >/etc/hosts
+  - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+  - mkdir -p /etc/pre-kubeadm-commands
+  - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort); do echo "Running script $script"; "$script"; done
+  sshAuthorizedKeys:
+  - ssh-rsa AAA
+  # files:
+  # - content: |
+  #     version = 2
+
+  #     imports = ["/etc/containerd/conf.d/*.toml"]
+
+  #     [plugins]
+  #       [plugins."io.containerd.grpc.v1.cri"]
+  #         sandbox_image = "registry.k8s.io/pause:3.9"
+  #       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  #         runtime_type = "io.containerd.runc.v2"
+  #       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+  #         SystemdCgroup = true
+  #       [plugins."io.containerd.grpc.v1.cri".registry]
+  #         config_path = "/etc/containerd/certs.d"
+  #   owner: root:root
+  #   path: /etc/containerd/config.toml
+  #   permissions: "0644"
+
+kubeadmControlPlane:
+  replicas: 1
+  template: template-name
+  version: v1.30.0
+
+machineDeployments:
+- name: md-0
+  replicas: 1
+  template: template-name
+  version: v1.30.0
+
+# If using InClusterIPAM can define list of InClusterIPPools
+inClusterIPPool: []
+# - name: control-plane-pool
+#   spec:
+#     addresses:
+#       - 10.1.1.10-10.1.1.20
+#     prefix: 24
+#     gateway: 10.1.1.1
+# - name: worker-pool
+#   spec:
+#     addresses:
+#       - 10.1.1.21-10.1.1.40
+#     prefix: 24
+#     gateway: 10.1.1.1
+
+extraResourcesConfigmaps:
+# - name: extra-configmap
+#   data: |-
+#     apiVersion: v1
+#     kind: Namespace
+#     metadata:
+#       name: extra-namespace
+
+
+extraResourcesSecrets:
+# - name: extra-secret
+#   data: |-
+#     apiVersion: v1
+#     kind: Secret
+#     metadata:
+#       name: extra-secret
+#     stringData:
+#       secretKey: secretValue

--- a/charts/clusterapi-resources/values.yaml
+++ b/charts/clusterapi-resources/values.yaml
@@ -137,3 +137,17 @@ extraResourcesSecrets:
 #       name: extra-secret
 #     stringData:
 #       secretKey: secretValue
+
+# Creates bigip-ctrl AS3 configmap for kubeapi endpoint with manual list of pool members
+bigipCtrlAS3:
+  enabled: false
+  # vs:
+  #   address: 10.0.12.1
+  #   port: 6443
+  # pool:
+  #   port: 6443
+  #   members:
+  #   - 10.1.1.10
+  #   - 10.1.1.12
+  #   - 10.1.1.13
+  #   - 10.1.1.14


### PR DESCRIPTION
### PR Description
This chart the objetive to make it simpler to generate the resources need to deploy a Kubernetes cluster using CAPI with the vsphere provider.

This first version contemplates a series of features, such as but not limited to:
- Kind `Cluster` customization
- Kind `VSphereCluster` customization
- List of `VSphereMachineTemplate` with a default option and individual overrides
- Kind `KubeadmControlPlane` customization
- List of `MachineDeployment` with some customization
- Control over deploy of Vsphere CSI and CPI

Extras:
- Create of list of `InClusterIPPool` in case we use `InClusterIPAM`
- List of extra `Configmaps` and `Secrets` to be added to the `ClusterResourceSet`
- Kind Configmap for bigip-ctrl AS3 configuration

### How to test
If you want to test this PR, I opened another https://github.com/powerhome/pacman/pull/80 with some values.

### Checklist

 - [ ] Have you reviewed and updated the chart default values if necessary?
 - [ ] Have you reviewed and updated the chart documentation if necessary?
 - [ ] Does your branch follow the naming convention of `{chartNameWithDashes}-v{versionString}-{optionalPatchVersion}`?
 - [ ] Have you bumped the version in the chart's `Chart.yaml`?

### Tagged Releases
Please remember to make a tagged release after merging your PR that:

 - Has a tag name that matches your PR branch name (see above)
 - Has a description that summarizes the changes made

This makes it possible to use previous versions of the charts maintained here as new releases are published. Please see the release history of this repository for examples.
