### PR TITLE
fix(clusterapi-resources): Add checksum for kubeadmconfig to trigger MachineDeployment rollout

### DIFF
--- a/charts/clusterapi-resources/Chart.yaml
+++ b/charts/clusterapi-resources/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version of clusterctl used as base to generate the templates
 appVersion: "1.8.3"

--- a/charts/clusterapi-resources/templates/MachineDeployment.yaml
+++ b/charts/clusterapi-resources/templates/MachineDeployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.machineDeployments }}
+{{- $checksum := include (print $.Template.BasePath "/KubeadmConfigTemplate.yaml") . | sha256sum }}
 {{- range $md := .Values.machineDeployments }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -15,6 +16,8 @@ spec:
     matchLabels: {}
   template:
     metadata:
+      annotations:
+        checksum/kubeadmconfig: {{ $checksum }}
       labels:
         cluster.x-k8s.io/cluster-name: {{ $.Values.cluster.name }}
     spec:


### PR DESCRIPTION
### PR Description
If we update the content of `kubeadmConfigSpec` it will trigger rollout of the Control planes but it won't for MachineDeployments since there wasn't a change on the resource itself. This PR adds an annotation with the checksum of kubeadmconfig to force a rollout of the MachineDeployment in case there is a change in the kubeadmconfig.

### Checklist

 - [ ] Have you reviewed and updated the chart default values if necessary?
 - [ ] Have you reviewed and updated the chart documentation if necessary?
 - [ ] Does your branch follow the naming convention of `{chartNameWithDashes}-v{versionString}-{optionalPatchVersion}`?
 - [x] Have you bumped the version in the chart's `Chart.yaml`?

### Tagged Releases
Please remember to make a tagged release after merging your PR that:

 - Has a tag name that matches your PR branch name (see above)
 - Has a description that summarizes the changes made

This makes it possible to use previous versions of the charts maintained here as new releases are published. Please see the release history of this repository for examples.
