### PR TITLE
find_multipaths is only valid in defaults section

### DIFF
--- a/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
+++ b/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
@@ -45,7 +45,6 @@ spec:
               no_path_retry               0
               features                    0
               dev_loss_tmo                60
-              find_multipaths             yes
             }
             device {
               vendor                   "PURE"
@@ -61,7 +60,6 @@ spec:
               no_path_retry            0
               features                 0
               dev_loss_tmo             600
-              find_multipaths          yes
             }
           }
           blacklist {


### PR DESCRIPTION
### PR Description
The option `find_multipaths` is only valid in defaults section. Which was causing multipathd to not load the config in `/etc/multipath.conf` because of the error:

```
Feb 07 12:47:40 wc-beta-hq-md-test-bx8x6-9ssln multipathd[323382]: /etc/multipath.conf line 18, invalid keyword in the device section: find_multipaths
Feb 07 12:47:40 wc-beta-hq-md-test-bx8x6-9ssln multipathd[323382]: /etc/multipath.conf line 34, invalid keyword in the device section: find_multipaths
Feb 07 12:47:40 wc-beta-hq-md-test-bx8x6-9ssln multipathd[323382]: /etc/multipath.conf line 18, invalid keyword in the device section: find_multipaths
Feb 07 12:47:40 wc-beta-hq-md-test-bx8x6-9ssln multipathd[323382]: /etc/multipath.conf line 34, invalid keyword in the device section: find_multipaths
```

### Checklist

 - [ ] Have you reviewed and updated the chart default values if necessary?
 - [ ] Have you reviewed and updated the chart documentation if necessary?
 - [ ] Does your branch follow the naming convention of `{chartNameWithDashes}-v{versionString}-{optionalPatchVersion}`?
 - [ ] Have you bumped the version in the chart's `Chart.yaml`?

### Tagged Releases
Please remember to make a tagged release after merging your PR that:

 - Has a tag name that matches your PR branch name (see above)
 - Has a description that summarizes the changes made

This makes it possible to use previous versions of the charts maintained here as new releases are published. Please see the release history of this repository for examples.
