### PR TITLE
fix(clusterapi-resources): Reload multipathd if multipath is enabled

### DIFF
--- a/charts/clusterapi-resources/Chart.yaml
+++ b/charts/clusterapi-resources/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.1
 
 # This is the version of clusterctl used as base to generate the templates
 appVersion: "1.8.3"

--- a/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
+++ b/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
@@ -76,6 +76,9 @@ spec:
 {{- end }}
       preKubeadmCommands:
       {{- toYaml $.Values.kubeadmConfigSpec.preKubeadmCommands | nindent 6 }}
+      {{- if $.Values.kubeadmConfigSpec.multipath.enabled }}
+      - {{ $.Values.kubeadmConfigSpec.multipath.reload_multipath_command }}
+      {{- end }}
       users:
       - name: capv
         sshAuthorizedKeys:

--- a/charts/clusterapi-resources/values.yaml
+++ b/charts/clusterapi-resources/values.yaml
@@ -116,6 +116,7 @@ kubeadmConfigSpec:
   multipath:
     enabled: false
     find_multipaths: no
+    reload_multipath_command: systemctl restart multipathd
 
   initConfiguration:
     skipPhases: []


### PR DESCRIPTION
### PR Description
Our chart allows the config of multipath, but since the file is created after the service is started, it never loads the new config. This PR address this issue by reloading multipathd as a pre kubeadm command.

### Checklist

 - [x] Have you reviewed and updated the chart default values if necessary?
 - [x] Have you reviewed and updated the chart documentation if necessary?
 - [ ] Does your branch follow the naming convention of `{chartNameWithDashes}-v{versionString}-{optionalPatchVersion}`?
 - [x] Have you bumped the version in the chart's `Chart.yaml`?

### Tagged Releases
Please remember to make a tagged release after merging your PR that:

 - Has a tag name that matches your PR branch name (see above)
 - Has a description that summarizes the changes made

This makes it possible to use previous versions of the charts maintained here as new releases are published. Please see the release history of this repository for examples.
