### PR TITLE
Update VSphere CPI to 1.32.2

### DIFF
--- a/charts/clusterapi-resources/Chart.yaml
+++ b/charts/clusterapi-resources/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.0
+version: 0.11.1
 
 # This is the version of clusterctl used as base to generate the templates
-appVersion: "1.8.3"
+appVersion: "1.9.6"

--- a/charts/clusterapi-resources/Chart.yaml
+++ b/charts/clusterapi-resources/Chart.yaml
@@ -4,6 +4,8 @@ description: A Helm chart for creating CAPI and CAPV resources.
 maintainers:
   - name: iblackman
     email: igor.blackman@powerhrg.com
+  - name: L30Bola
+    email: leonardo.godoy@powerhrg.com
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/clusterapi-resources/templates/ConfigMapsCPIManifests.yaml
+++ b/charts/clusterapi-resources/templates/ConfigMapsCPIManifests.yaml
@@ -163,7 +163,7 @@ data:
           priorityClassName: system-node-critical
           containers:
           - name: vsphere-cpi
-            image: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
+            image: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.2
             imagePullPolicy: IfNotPresent
             args:
               - --cloud-provider=vsphere


### PR DESCRIPTION
### PR Description
In preparation for the upgrade of the Kube clusters, we had to upgrade our MC providers. 

Updates the chart version and appVersion, since the wasn't any change needed to use CAPI 1.9.6 and the CAPV 1.12.0 only updated the VSphere CPI version to 1.32.2.

### Checklist

 - [x] Have you reviewed and updated the chart default values if necessary?
 - [ ] Have you reviewed and updated the chart documentation if necessary?
 - [ ] Does your branch follow the naming convention of `{chartNameWithDashes}-v{versionString}-{optionalPatchVersion}`?
 - [x] Have you bumped the version in the chart's `Chart.yaml`?

### Tagged Releases
Please remember to make a tagged release after merging your PR that:

 - Has a tag name that matches your PR branch name (see above)
 - Has a description that summarizes the changes made

This makes it possible to use previous versions of the charts maintained here as new releases are published. Please see the release history of this repository for examples.
