### PR TITLE
Move VSphere resourceSet to its own with reconcile

### DIFF
--- a/charts/clusterapi-resources/Chart.yaml
+++ b/charts/clusterapi-resources/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.1
+version: 1.0.0
 
 # This is the version of clusterctl used as base to generate the templates
 appVersion: "1.9.6"

--- a/charts/clusterapi-resources/templates/ClusterResourceSet.yaml
+++ b/charts/clusterapi-resources/templates/ClusterResourceSet.yaml
@@ -12,20 +12,6 @@ spec:
     matchLabels:
       cluster.x-k8s.io/cluster-name: {{ .Values.cluster.name }}
   resources:
-  - kind: Secret
-    name: vsphere-config-secret
-  - kind: Secret
-    name: cloud-provider-vsphere-credentials
-{{- if .Values.vsphereCluster.csi.enabled }}
-  - kind: ConfigMap
-    name: csi-manifests
-{{- end }}
-{{- if .Values.vsphereCluster.cpi.enabled }}
-  - kind: ConfigMap
-    name: cpi-manifests
-  - kind: ConfigMap
-    name: cpi-manifests-cloud-config
-{{- end }}
 {{- range $md := .Values.extraResourcesConfigmaps }}
   - kind: ConfigMap
     name: {{ $md.name }}
@@ -43,4 +29,32 @@ spec:
     name: add-cluster-to-argo
   - kind: Secret
     name: add-cluster-to-argo
+{{- end }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: {{ .Values.cluster.name }}
+  name: {{ .Values.cluster.name }}-crs-reconcile
+  namespace: {{ $.Release.Namespace }}
+spec:
+  strategy: Reconcile
+  clusterSelector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ .Values.cluster.name }}
+  resources:
+  - kind: Secret
+    name: vsphere-config-secret
+  - kind: Secret
+    name: cloud-provider-vsphere-credentials
+{{- if .Values.vsphereCluster.csi.enabled }}
+  - kind: ConfigMap
+    name: csi-manifests
+{{- end }}
+{{- if .Values.vsphereCluster.cpi.enabled }}
+  - kind: ConfigMap
+    name: cpi-manifests
+  - kind: ConfigMap
+    name: cpi-manifests-cloud-config
 {{- end }}

--- a/charts/clusterapi-resources/templates/ClusterResourceSet.yaml
+++ b/charts/clusterapi-resources/templates/ClusterResourceSet.yaml
@@ -1,3 +1,7 @@
+
+{{- $lenExtraResourcesConfigmaps := len .Values.extraResourcesConfigmaps }}
+{{- $lenExtraResourcesSecrets := len .Values.extraResourcesSecrets }}
+{{- if or .Values.cni.install (or .Values.argo.enabled (or (gt $lenExtraResourcesConfigmaps 0) (gt $lenExtraResourcesSecrets 0))) }}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -29,6 +33,7 @@ spec:
     name: add-cluster-to-argo
   - kind: Secret
     name: add-cluster-to-argo
+{{- end }}
 {{- end }}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
### PR Description
In order to not have to manage the VSphere resources deployed via `ClusterResourceSet` outside the pacman repo, this PR moves them to their own `ClusterResourceSet` with `strategy: Reconcile`.

I decided to bump the major version because it changes an existing resource and the new one will be reconciling which it didn't do before.

### Checklist

 - [x] Have you reviewed and updated the chart default values if necessary?
 - [ ] Have you reviewed and updated the chart documentation if necessary?
 - [ ] Does your branch follow the naming convention of `{chartNameWithDashes}-v{versionString}-{optionalPatchVersion}`?
 - [x] Have you bumped the version in the chart's `Chart.yaml`?

### Tagged Releases
Please remember to make a tagged release after merging your PR that:

 - Has a tag name that matches your PR branch name (see above)
 - Has a description that summarizes the changes made

This makes it possible to use previous versions of the charts maintained here as new releases are published. Please see the release history of this repository for examples.
