### PR TITLE
Allow Passing "node-labels"

### DIFF
--- a/charts/clusterapi-resources/Chart.yaml
+++ b/charts/clusterapi-resources/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version of clusterctl used as base to generate the templates
 appVersion: "1.9.6"

--- a/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
+++ b/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
@@ -14,11 +14,14 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             cloud-provider: external
+          {{- if $md.node-labels }}
+            node-labels: {{ $md.node-labels}}
+          {{- end }}
           name: '{{`{{ local_hostname }}`}}'
         {{- if and $md.taints (gt (len $md.taints) 0) }}
           taints:
           {{- toYaml $md.taints | nindent 10 }}
-        {{- end}}
+        {{- end }}
 {{- with $.Values.kubeadmConfigSpec.files }}
       files:
       {{- toYaml . | nindent 6 }}

--- a/charts/clusterapi-resources/values.yaml
+++ b/charts/clusterapi-resources/values.yaml
@@ -138,6 +138,8 @@ machineDeployments:
   # taints:
   #   - effect: NoExecute
   #     key: nvidia.com/gpu
+  # String of comma separated key=value pairs to add to nodes created by this machineDeployments
+  # node-labels: custom-label=hello-world
 
 # If using InClusterIPAM can define list of InClusterIPPools
 inClusterIPPool: []


### PR DESCRIPTION
The motivation for this PR is to enable the ability to apply custom labels to nodes.

In METAL's use-case, we need to add custom labels on our nodes in order to specify the MIG configuration, which the operator will note and act accordingly.

https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/