### PR TITLE
Add support for additional disks in VSphereMachineTemplate

### DIFF
--- a/charts/clusterapi-resources/Chart.yaml
+++ b/charts/clusterapi-resources/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.3.0
 
 # This is the version of clusterctl used as base to generate the templates
 appVersion: "1.9.6"

--- a/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
+++ b/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
@@ -26,6 +26,9 @@ spec:
       files:
       {{- toYaml . | nindent 6 }}
 {{- end }}
+{{- with $.Values.kubeadmConfigSpec.kubeadmConfigTemplateFiles }}
+      {{- toYaml . | nindent 6 }}
+{{- end }}
 {{- if $.Values.kubeadmConfigSpec.multipath.enabled }}
   {{- if lt (len $.Values.kubeadmConfigSpec.files) 1 }}
       files:

--- a/charts/clusterapi-resources/templates/VSphereMachineTemplate.yaml
+++ b/charts/clusterapi-resources/templates/VSphereMachineTemplate.yaml
@@ -14,6 +14,7 @@ spec:
       datacenter: {{ $t.spec.datacenter | default $.Values.vsphereCluster.datacenter }}
       datastore: {{ $t.spec.datastore | default $defaultSpec.datastore }}
       diskGiB: {{ $t.spec.diskGiB | default $defaultSpec.diskGiB }}
+      additionalDisksGiB: {{ $t.spec.additionalDisksGiB | default $defaultSpec.additionalDisksGiB }}
       folder: {{ $t.spec.folder | default $defaultSpec.folder }}
       memoryMiB: {{ $t.spec.memoryMiB | default $defaultSpec.memoryMiB }}
       network:

--- a/charts/clusterapi-resources/templates/VSphereMachineTemplate.yaml
+++ b/charts/clusterapi-resources/templates/VSphereMachineTemplate.yaml
@@ -14,7 +14,9 @@ spec:
       datacenter: {{ $t.spec.datacenter | default $.Values.vsphereCluster.datacenter }}
       datastore: {{ $t.spec.datastore | default $defaultSpec.datastore }}
       diskGiB: {{ $t.spec.diskGiB | default $defaultSpec.diskGiB }}
-      additionalDisksGiB: {{ $t.spec.additionalDisksGiB | default $defaultSpec.additionalDisksGiB }}
+    {{- if $t.spec.additionalDisksGiB }}
+      additionalDisksGiB: {{ $t.spec.additionalDisksGiB }}
+    {{- end }}
       folder: {{ $t.spec.folder | default $defaultSpec.folder }}
       memoryMiB: {{ $t.spec.memoryMiB | default $defaultSpec.memoryMiB }}
       network:

--- a/charts/clusterapi-resources/values.yaml
+++ b/charts/clusterapi-resources/values.yaml
@@ -32,6 +32,7 @@ vsphereMachineTemplate:
     spec:
       cloneMode: linkedClone
       datastore: DATASTORE
+      additionalDisksGiB: []
       diskGiB: 50
       folder: FOLDER
       memoryMiB: 8192

--- a/charts/clusterapi-resources/values.yaml
+++ b/charts/clusterapi-resources/values.yaml
@@ -32,8 +32,11 @@ vsphereMachineTemplate:
     spec:
       cloneMode: linkedClone
       datastore: DATASTORE
-      additionalDisksGiB: []
       diskGiB: 50
+      ## default for additionalDisksGiB is unset but you can specify it as this:
+      # additionalDisksGiB:
+      # - 50
+      # - 100
       folder: FOLDER
       memoryMiB: 8192
       network:

--- a/charts/clusterapi-resources/values.yaml
+++ b/charts/clusterapi-resources/values.yaml
@@ -98,6 +98,13 @@ kubeadmConfigSpec:
   - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort); do echo "Running script $script"; "$script"; done
   sshAuthorizedKeys:
   - ssh-rsa AAA
+  ### About FILES ###
+  ## There are 2 ways of adding files to the nodes using this chart:
+  ## 1. Using the "files" attribute will render the files both on KubeadmControlPlane (used
+  ##    for control nodes) and KubeadmConfigTemplate (used for worker nodes) objects.
+  ## 2. Using the "kubeadmConfigTemplateFiles" attribute will render the files only on
+  ##    KubeadmConfigTemplate objects, so only on worker nodes.
+  ##
   # files:
   # - content: |
   #     version = 2
@@ -116,6 +123,13 @@ kubeadmConfigSpec:
   #   owner: root:root
   #   path: /etc/containerd/config.toml
   #   permissions: "0644"
+  #
+  # kubeadmConfigTemplateFiles:
+  # - content: |
+  #     # Some file to be placed only on the worker nodes
+  #   owner: root:root
+  #   path: /etc/pre-kubeadm-commands/00-mkfs-worker.sh
+  #   permissions: "0755"
   multipath:
     enabled: false
     find_multipaths: no


### PR DESCRIPTION
### PR Description
Add support for additional disks in VSphereMachineTemplate, so we can  add extra disks to nodes created by Cluster API on VSphere.

It does that by supporting the additionalDisksGiB attribute, but omitting it in the rendered object if value is unset.

This is because VsphereMachineTemplates are immutable objects. So adding this attribute set to an empty list on an existent object triggers an error on Kubernetes, because it is considered a change in the spec.

This will trigger errors for existing VsphereMachineTemplates that don't need extra disks, and have no change at all, causing us trouble. So instead of adding that empty default, we omit the attribute when unset, and document its existence.

### Checklist

 - [x] Have you reviewed and updated the chart default values if necessary?
 - [x] Have you reviewed and updated the chart documentation if necessary?
 - [x] Does your branch follow the naming convention of `{chartNameWithDashes}-v{versionString}-{optionalPatchVersion}`?
 - [x] Have you bumped the version in the chart's `Chart.yaml`?


### Tests

I have tested this version together with the changes on https://github.com/powerhome/pacman/pull/190. It is being successfully used by this ArgoCD application:
https://cd.mc.prod.hq.powerapp.cloud/applications/argo/clusterapi-wc-alpha-gm
