### PR TITLE
Add support for passing kubeletExtraArgs as values

### DIFF
--- a/charts/clusterapi-resources/Chart.yaml
+++ b/charts/clusterapi-resources/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.4.0
 
 # This is the version of clusterctl used as base to generate the templates
 appVersion: "1.9.6"

--- a/charts/clusterapi-resources/Chart.yaml
+++ b/charts/clusterapi-resources/Chart.yaml
@@ -6,6 +6,8 @@ maintainers:
     email: igor.blackman@powerhrg.com
   - name: L30Bola
     email: leonardo.godoy@powerhrg.com
+  - name: dgmorales
+    email: dmorales@powerhrg.com
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
+++ b/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
@@ -11,14 +11,14 @@ spec:
     spec:
       initConfiguration:
         nodeRegistration:
-          criSocket: /var/run/containerd/containerd.sock
+          criSocket: unix:///var/run/containerd/containerd.sock
 {{- with $.Values.kubeadmConfigSpec.initConfiguration.kubeletExtraArgs }}
           kubeletExtraArgs:
             {{- toYaml . | nindent 12 }}
 {{- end }}
       joinConfiguration:
         nodeRegistration:
-          criSocket: /var/run/containerd/containerd.sock
+          criSocket: unix:///var/run/containerd/containerd.sock
 {{- with $.Values.kubeadmConfigSpec.joinConfiguration.kubeletExtraArgs }}
           kubeletExtraArgs:
             cloud-provider: external

--- a/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
+++ b/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
@@ -9,11 +9,21 @@ metadata:
 spec:
   template:
     spec:
+      initConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+{{- with $.Values.kubeadmConfigSpec.initConfiguration.kubeletExtraArgs }}
+          kubeletExtraArgs:
+            {{- toYaml . | nindent 12 }}
+{{- end }}
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+{{- with $.Values.kubeadmConfigSpec.joinConfiguration.kubeletExtraArgs }}
           kubeletExtraArgs:
             cloud-provider: external
+            {{- toYaml . | nindent 12 }}
+{{- end }}
           {{- if $md.nodeLabels }}
             node-labels: {{ $md.nodeLabels}}
           {{- end }}

--- a/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
+++ b/charts/clusterapi-resources/templates/KubeadmConfigTemplate.yaml
@@ -9,19 +9,12 @@ metadata:
 spec:
   template:
     spec:
-      initConfiguration:
-        nodeRegistration:
-          criSocket: unix:///var/run/containerd/containerd.sock
-{{- with $.Values.kubeadmConfigSpec.initConfiguration.kubeletExtraArgs }}
-          kubeletExtraArgs:
-            {{- toYaml . | nindent 12 }}
-{{- end }}
       joinConfiguration:
         nodeRegistration:
           criSocket: unix:///var/run/containerd/containerd.sock
-{{- with $.Values.kubeadmConfigSpec.joinConfiguration.kubeletExtraArgs }}
           kubeletExtraArgs:
             cloud-provider: external
+{{- with $.Values.kubeadmConfigSpec.joinConfiguration.kubeletExtraArgs }}
             {{- toYaml . | nindent 12 }}
 {{- end }}
           {{- if $md.nodeLabels }}

--- a/charts/clusterapi-resources/templates/KubeadmControlPlane.yaml
+++ b/charts/clusterapi-resources/templates/KubeadmControlPlane.yaml
@@ -30,7 +30,7 @@ spec:
     initConfiguration:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
-{{- with $.Values.kubeadmConfigSpec.initConfiguration.kubeletExtraArgs }}
+{{- with $.Values.kubeadmConfigSpec.joinConfiguration.kubeletExtraArgs }}
         kubeletExtraArgs:
           cloud-provider: external
           {{- toYaml . | nindent 10 }}

--- a/charts/clusterapi-resources/templates/KubeadmControlPlane.yaml
+++ b/charts/clusterapi-resources/templates/KubeadmControlPlane.yaml
@@ -32,7 +32,7 @@ spec:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
-{{- with $.Values.kubeadmConfigSpec.joinConfiguration.kubeletExtraArgs }}
+{{- with $.Values.kubeadmConfigSpec.initConfiguration.kubeletExtraArgs }}
           {{- toYaml . | nindent 10 }}
 {{- end }}
         name: '{{`{{ local_hostname }}`}}'
@@ -45,7 +45,7 @@ spec:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
-{{- with $.Values.kubeadmConfigSpec.initConfiguration.kubeletExtraArgs }}
+{{- with $.Values.kubeadmConfigSpec.joinConfiguration.kubeletExtraArgs }}
           {{- toYaml . | nindent 10 }}
 {{- end }}
         name: '{{`{{ local_hostname }}`}}'

--- a/charts/clusterapi-resources/templates/KubeadmControlPlane.yaml
+++ b/charts/clusterapi-resources/templates/KubeadmControlPlane.yaml
@@ -30,9 +30,9 @@ spec:
     initConfiguration:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
-{{- with $.Values.kubeadmConfigSpec.joinConfiguration.kubeletExtraArgs }}
         kubeletExtraArgs:
           cloud-provider: external
+{{- with $.Values.kubeadmConfigSpec.joinConfiguration.kubeletExtraArgs }}
           {{- toYaml . | nindent 10 }}
 {{- end }}
         name: '{{`{{ local_hostname }}`}}'
@@ -43,9 +43,9 @@ spec:
     joinConfiguration:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
-{{- with $.Values.kubeadmConfigSpec.initConfiguration.kubeletExtraArgs }}
         kubeletExtraArgs:
           cloud-provider: external
+{{- with $.Values.kubeadmConfigSpec.initConfiguration.kubeletExtraArgs }}
           {{- toYaml . | nindent 10 }}
 {{- end }}
         name: '{{`{{ local_hostname }}`}}'

--- a/charts/clusterapi-resources/templates/KubeadmControlPlane.yaml
+++ b/charts/clusterapi-resources/templates/KubeadmControlPlane.yaml
@@ -30,8 +30,11 @@ spec:
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
+{{- with $.Values.kubeadmConfigSpec.initConfiguration.kubeletExtraArgs }}
         kubeletExtraArgs:
           cloud-provider: external
+          {{- toYaml . | nindent 10 }}
+{{- end }}
         name: '{{`{{ local_hostname }}`}}'
 {{- with .Values.kubeadmConfigSpec.initConfiguration.skipPhases }}
       skipPhases:
@@ -40,8 +43,11 @@ spec:
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
+{{- with $.Values.kubeadmConfigSpec.initConfiguration.kubeletExtraArgs }}
         kubeletExtraArgs:
           cloud-provider: external
+          {{- toYaml . | nindent 10 }}
+{{- end }}
         name: '{{`{{ local_hostname }}`}}'
     preKubeadmCommands:
     {{- toYaml .Values.kubeadmConfigSpec.preKubeadmCommands | nindent 4 }}

--- a/charts/clusterapi-resources/templates/KubeadmControlPlane.yaml
+++ b/charts/clusterapi-resources/templates/KubeadmControlPlane.yaml
@@ -29,7 +29,7 @@ spec:
 {{- end }}
     initConfiguration:
       nodeRegistration:
-        criSocket: /var/run/containerd/containerd.sock
+        criSocket: unix:///var/run/containerd/containerd.sock
 {{- with $.Values.kubeadmConfigSpec.initConfiguration.kubeletExtraArgs }}
         kubeletExtraArgs:
           cloud-provider: external
@@ -42,7 +42,7 @@ spec:
 {{- end }}
     joinConfiguration:
       nodeRegistration:
-        criSocket: /var/run/containerd/containerd.sock
+        criSocket: unix:///var/run/containerd/containerd.sock
 {{- with $.Values.kubeadmConfigSpec.initConfiguration.kubeletExtraArgs }}
         kubeletExtraArgs:
           cloud-provider: external

--- a/charts/clusterapi-resources/values.yaml
+++ b/charts/clusterapi-resources/values.yaml
@@ -137,10 +137,14 @@ kubeadmConfigSpec:
     enabled: false
     find_multipaths: no
     reload_multipath_command: systemctl restart multipathd
-
   initConfiguration:
     skipPhases: []
     # List of phases to skip - `kubeadm init --help` for more info
+    # kubeletExtraArgs:
+    #   config: /etc/kubernetes/kubelet-config.yaml
+  # joinConfiguration:
+  #   kubeletExtraArgs:
+  #   config: /etc/kubernetes/kubelet-config.yaml
 
 kubeadmControlPlane:
   replicas: 1

--- a/charts/clusterapi-resources/values.yaml
+++ b/charts/clusterapi-resources/values.yaml
@@ -140,10 +140,10 @@ kubeadmConfigSpec:
   initConfiguration:
     skipPhases: []
     # List of phases to skip - `kubeadm init --help` for more info
-    # kubeletExtraArgs:
+    kubeletExtraArgs: {}
     #   config: /etc/kubernetes/kubelet-config.yaml
-  # joinConfiguration:
-  #   kubeletExtraArgs:
+  joinConfiguration:
+    kubeletExtraArgs: {}
   #   config: /etc/kubernetes/kubelet-config.yaml
 
 kubeadmControlPlane:


### PR DESCRIPTION
### PR Description
This PR adds support for passing kubeletExtraArgs as values, so we can pass a config arg, required for https://github.com/powerhome/pacman/pull/213.

It also updates the containerd socket reference style to fix a complaint on kubelet logs.

### Checklist

 - [x] Have you reviewed and updated the chart default values if necessary?
 - [x] Have you reviewed and updated the chart documentation if necessary?
 - [x] Does your branch follow the naming convention of `{chartNameWithDashes}-v{versionString}-{optionalPatchVersion}`?
 - [x] Have you bumped the version in the chart's `Chart.yaml`?

### Tagged Releases

Please remember to make a tagged release after merging your PR that.

### Tests

- Manually tested on alpha cluster
- Tested on alpha going through ArgoCD
